### PR TITLE
SPLADE_GPU: up to 10x faster search using NVIDIA GPUs with PyTorch and CUDA

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Run core tests
         run: |
           python -m unittest discover -s tests/core
+          python -m unittest discover -s tests/pytorch
 
       - name: Install Numba
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -184,4 +184,5 @@ bm25s_indices/
 # test file
 test.py
 test_hf.py
+test_gpu.py
 animal_index_splade/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ SPLADE-Index is an ultrafast search index for SPLADE sparse retrieval models imp
 </i>
 <br/><br/>
 
+You can use `splade-index` to 
+- Index and Query up to millions of documents using any SPLADE Sparse Embedding (SparseEncoder) model supported by `sentence-transformers` such as `naver/spalde-v3`.
+- Save your index locally and load your index from the save files.
+- Upload your index to huggingface hub and let anyone else download and use it.
+- Make use of NVIDIA GPUs and PyTorch for 10x faster search compared to `splade-index`'s CPU based `numba` backend, when your index contains 1 million plus documents.
+
+## SPLADE
+
 SPLADE is a neural retrieval model which learns query/document sparse expansion. Sparse representations benefit from several advantages compared to dense approaches: efficient use of inverted index, explicit lexical match, interpretability... They also seem to be better at generalizing on out-of-domain data (BEIR benchmark).
 
 For more information about SPLADE models, please refer to the following. 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ SPLADE-Index is an ultrafast search index for SPLADE sparse retrieval models imp
 <br/><br/>
 
 You can use `splade-index` to 
-- Index and Query up to millions of documents using any SPLADE Sparse Embedding (SparseEncoder) model supported by `sentence-transformers` such as `naver/spalde-v3`.
-- Save your index locally and load your index from the save files.
-- Upload your index to huggingface hub and let anyone else download and use it.
-- Make use of NVIDIA GPUs and PyTorch for 10x faster search compared to `splade-index`'s CPU based `numba` backend, when your index contains 1 million plus documents.
+
+✅ Index and Query up to millions of documents using any SPLADE Sparse Embedding (SparseEncoder) model supported by `sentence-transformers` such as `naver/spalde-v3`.
+
+✅ Save your index locally and load your index from the save files.
+
+✅ Upload your index to huggingface hub and let anyone else download and use it.
+
+✅ Use memory mapping to load large indices with minimal RAM usage and no noticeable change in search latency (Loading a 1 Million document index with mmap uses just 2GB of RAM).
+
+✅ Make use of NVIDIA GPUs and PyTorch for 10x faster search compared to `splade-index`'s CPU based `numba` backend, when your index contains 1 million plus documents.
 
 ## SPLADE
 
@@ -143,6 +149,38 @@ queries = ["does the fish purr like a cat?"]
 
 # Get top-k results as a tuple of (doc ids, documents, scores). All three are arrays of shape (n_queries, k).
 results = retriever.retrieve(queries, k=2)
+doc_ids, result_docs, scores = results.doc_ids, results.documents, results.scores
+
+for i in range(doc_ids.shape[1]):
+    doc_id, doc, score = doc_ids[0, i], result_docs[0, i], scores[0, i]
+    print(f"Rank {i+1} (score: {score:.2f}) (doc_id: {doc_id}): {doc}")
+```
+
+## 10x faster search with SPLADE_GPU
+
+For large indices with 1 million plus documents, you can use `SPLADE_GPU` for 10x higher search throughput (queries/second) relative to `splade-index`'s already fast CPU based `numba` backend. In order to use `SPLADE_GPU`, you need to have an NVIDIA GPU and a pytorch installation with CUDA.
+
+```python
+from sentence_transformers import SparseEncoder
+from splade_index.pytorch import SPLADE_GPU
+
+# Download a SPLADE model from the 🤗 Hub
+model = SparseEncoder("rasyosef/splade-mini", device="cuda")
+
+# Load a SPLADE index from the Hugging Face model hub
+repo_id = "rasyosef/msmarco_dev_1M_splade_index"
+retriever = SPLADE_GPU.load_from_hub(
+    repo_id, 
+    model=model, 
+    mmap=True, # memory mapping enabled for low RAM usage
+    device="cuda"
+)
+
+# Query the corpus
+queries = ["what is a corporation?", "do owls eat in the day", "average pharmacy tech salary"]
+
+# Get top-k results as a tuple of (doc ids, documents, scores). All three are arrays of shape (n_queries, k).
+results = retriever.retrieve(queries, k=5)
 doc_ids, result_docs, scores = results.doc_ids, results.documents, results.scores
 
 for i in range(doc_ids.shape[1]):

--- a/README.md
+++ b/README.md
@@ -5,17 +5,13 @@ SPLADE-Index is an ultrafast search index for SPLADE sparse retrieval models imp
 </i>
 <br/><br/>
 
-You can use `splade-index` to 
+#### You can use `splade-index` to 
 
-✅ Index and Query up to millions of documents using any SPLADE Sparse Embedding (SparseEncoder) model supported by `sentence-transformers` such as `naver/spalde-v3`.
-
-✅ Save your index locally and load your index from the save files.
-
-✅ Upload your index to huggingface hub and let anyone else download and use it.
-
-✅ Use memory mapping to load large indices with minimal RAM usage and no noticeable change in search latency (Loading a 1 Million document index with mmap uses just 2GB of RAM).
-
-✅ Make use of NVIDIA GPUs and PyTorch for 10x faster search compared to `splade-index`'s CPU based `numba` backend, when your index contains 1 million plus documents.
+* ✅ Index and Query up to millions of documents using any SPLADE Sparse Embedding ([SparseEncoder](https://sbert.net/docs/sparse_encoder/usage/usage.html)) model supported by [sentence-transformers](https://sbert.net/) such as `naver/spalde-v3`.
+* 📀 Save your index locally and load your index from the save files.
+* 🤗 Upload your index to HuggingFace hub and let anyone else download and use it.
+* 🪶 Use memory mapping to load large indices with minimal RAM usage and no noticeable change in search latency (Loading a 1 Million document index with mmap uses just 2GB of RAM).
+* ⚡ Make use of NVIDIA GPUs and PyTorch for 10x faster search compared to `splade-index`'s CPU based `numba` backend, when your index contains 1 million plus documents.
 
 ## SPLADE
 

--- a/splade_index/pytorch.py
+++ b/splade_index/pytorch.py
@@ -91,7 +91,7 @@ class SPLADE_GPU:
         dtype="float32",
         int_dtype="int32",
         backend: Literal["auto", "numpy"] = "numpy",
-        device: Literal["cuda", "mps", "cpu"] = "cuda",
+        device: Literal["cuda", "cpu"] = "cuda",
     ):
         """
         SPLADE initialization.
@@ -112,9 +112,7 @@ class SPLADE_GPU:
 
         device : str
             the accelerator device where the index torch tensors are to be moved for faster computation.
-            Set `device` to "cuda" to make use of your NVIDIA GPUs or "mps" to use your Apple Silicon GPUs.
             "cuda"- For computations on NVIDIA GPUs using CUDA.
-            "mps": For computations on Apple's Metal Performance Shaders (MPS) framework.
             "cpu" - For computations on the Central Processing Unit.
         """
         self.dtype = dtype
@@ -130,13 +128,6 @@ class SPLADE_GPU:
             else:
                 raise ValueError(
                     f"`device` is set to 'cuda' but CUDA is not available with your current pytorch installation. Please install PyTorch with CUDA or choose a different `device`."
-                )
-        elif device == "mps":
-            if torch.backends.mps.is_available():
-                self.device = device
-            else:
-                raise ValueError(
-                    f"`device` is set to 'mps' but MPS is not available with your current pytorch installation. Please install PyTorch with MPS or choose a different `device`."
                 )
         else:
             self.device = device
@@ -241,7 +232,7 @@ class SPLADE_GPU:
         query_token_ids: np.ndarray,
         query_token_weights: np.ndarray,
         dtype: np.dtype,
-        device="cuda",
+        device: Literal["cuda", "cpu"] = "cuda",
     ) -> np.ndarray:
         """
         This internal static function calculates the relevance scores for a given query,
@@ -294,7 +285,7 @@ class SPLADE_GPU:
         self,
         query_token_ids_single: List[int],
         query_token_weights_single: List[float],
-        device: str,
+        device: Literal["cuda", "cpu"] = "cuda",
     ) -> np.ndarray:
 
         data = self.scores["data"]
@@ -334,7 +325,7 @@ class SPLADE_GPU:
         k: int = 1000,
         backend="auto",
         sorted: bool = False,
-        device: str = "cuda",
+        device: Literal["cuda", "cpu"] = "cuda",
     ):
         """
         This function is used to retrieve the top-k results for a single query.
@@ -660,7 +651,7 @@ class SPLADE_GPU:
         load_corpus=True,
         mmap=False,
         load_vocab=True,
-        device: Literal["cuda", "mps", "cpu"] = "cuda",
+        device: Literal["cuda", "cpu"] = "cuda",
     ):
         """
         Load a SPLADE index that was saved using the `save` method.
@@ -701,9 +692,7 @@ class SPLADE_GPU:
 
         device : str
             the accelerator device where the index torch tensors are to be moved for faster computation.
-            Set `device` to "cuda" to make use of your NVIDIA GPUs or "mps" to use your Apple Silicon GPUs.
             "cuda"- For computations on NVIDIA GPUs using CUDA.
-            "mps": For computations on Apple's Metal Performance Shaders (MPS) framework.
             "cpu" - For computations on the Central Processing Unit.
         """
         if not isinstance(mmap, bool):
@@ -879,7 +868,7 @@ class SPLADE_GPU:
         local_dir=None,
         load_corpus=True,
         mmap=False,
-        device: Literal["cuda", "mps", "cpu"] = "cuda",
+        device: Literal["cuda", "cpu"] = "cuda",
     ):
         """
         This function loads the SPLADE index from the Hugging Face Hub.
@@ -911,9 +900,7 @@ class SPLADE_GPU:
 
         device : str
             the accelerator device where the index torch tensors are to be moved for faster computation.
-            Set `device` to "cuda" to make use of your NVIDIA GPUs or "mps" to use your Apple Silicon GPUs.
             "cuda"- For computations on NVIDIA GPUs using CUDA.
-            "mps": For computations on Apple's Metal Performance Shaders (MPS) framework.
             "cpu" - For computations on the Central Processing Unit.
         """
 

--- a/tests/pytorch/test_pytorch_retrieve.py
+++ b/tests/pytorch/test_pytorch_retrieve.py
@@ -1,0 +1,93 @@
+import unittest
+import numpy as np
+from splade_index.pytorch import SPLADE_GPU
+from sentence_transformers import SparseEncoder
+
+
+class TestSpladeIndexPyTorchRetrieval(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+
+        # Download SPLADE from the 🤗 Hub
+        model = SparseEncoder("rasyosef/splade-tiny")
+
+        # Create your corpus here
+        corpus = np.array(
+            [
+                "a cat is a feline and likes to purr",
+                "a dog is the human's best friend and loves to play",
+                "a bird is a beautiful animal that can fly",
+                "a fish is a creature that lives in water and swims",
+            ]
+        )
+
+        document_ids = ["zero", "one", "two", "three"]
+
+        # Create the SPLADE retriever and index the corpus
+        retriever = SPLADE_GPU(device="cpu")
+        retriever.index(model=model, documents=corpus, document_ids=document_ids)
+
+        # Save the retriever to temp dir
+        cls.retriever = retriever
+        cls.corpus = corpus
+        cls.document_ids = document_ids
+
+    def test_retrieve(self):
+        ground_truth_ids = np.array([["zero", "three"]])
+        ground_truth_scores = np.array([[15.67, 8.17]], dtype="float32")
+        ground_truth_docs = np.array(
+            [
+                [
+                    "a cat is a feline and likes to purr",
+                    "a fish is a creature that lives in water and swims",
+                ]
+            ]
+        )
+        default_backend = "numpy"
+
+        queries = np.array(["does the fish purr like a cat?"])
+
+        # Get top-k results as a tuple of (doc ids, documents, scores). All three are arrays of shape (n_queries, k).
+        results = self.retriever.retrieve(queries, k=2)
+        doc_ids, result_docs, scores = (
+            results.doc_ids,
+            results.documents,
+            results.scores,
+        )
+
+        scores = np.round(scores, decimals=2)
+
+        self.assertEqual(
+            self.retriever.backend,
+            default_backend,
+            f"Expected {default_backend}, got {self.retriever.backend}",
+        )
+
+        self.assertTrue(
+            np.array_equal(doc_ids, ground_truth_ids),
+            f"Expected {ground_truth_ids}, got {doc_ids}",
+        )
+
+        self.assertTrue(
+            np.array_equal(scores, ground_truth_scores),
+            f"Expected {ground_truth_scores}, got {scores}",
+        )
+
+        self.assertTrue(
+            np.array_equal(result_docs, ground_truth_docs),
+            f"Expected {ground_truth_docs}, got {result_docs}",
+        )
+
+        # return_as = "doc_ids"
+        document_ids = self.retriever.retrieve(queries, k=2, return_as="doc_ids")
+        self.assertTrue(
+            np.array_equal(doc_ids, ground_truth_ids),
+            f"Expected {ground_truth_ids}, got {document_ids}",
+        )
+
+        # return_as = "documents"
+        documents = self.retriever.retrieve(queries, k=2, return_as="documents")
+        self.assertTrue(
+            np.array_equal(result_docs, ground_truth_docs),
+            f"Expected {ground_truth_docs}, got {documents}",
+        )

--- a/tests/pytorch/test_pytorch_save_load.py
+++ b/tests/pytorch/test_pytorch_save_load.py
@@ -1,0 +1,147 @@
+import os
+import unittest
+import tempfile
+import shutil
+import numpy as np
+from splade_index.pytorch import SPLADE_GPU
+from sentence_transformers import SparseEncoder
+
+
+class TestSpladeIndexSaveLoad(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+
+        # Download SPLADE from the 🤗 Hub
+        model = SparseEncoder("rasyosef/splade-tiny")
+
+        # Create your corpus here
+        corpus = np.array(
+            [
+                "a cat is a feline and likes to purr",
+                "a dog is the human's best friend and loves to play",
+                "a bird is a beautiful animal that can fly",
+                "a fish is a creature that lives in water and swims",
+            ]
+        )
+
+        document_ids = ["zero", "one", "two", "three"]
+
+        # Create the SPLADE retriever and index the corpus
+        retriever = SPLADE_GPU(device="cpu")
+        retriever.index(model=model, documents=corpus, document_ids=document_ids)
+
+        # Save the retriever to temp dir
+        cls.retriever = retriever
+        cls.model = model
+        cls.corpus = corpus
+        cls.document_ids = document_ids
+        cls.temp_save_dir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        # remove the temp dir with rmtree
+        shutil.rmtree(cls.temp_save_dir)
+
+    def test_save(self):
+        self.retriever.save(self.temp_save_dir)
+
+        filenames = [
+            "csc.index.npz",
+            "corpus.jsonl",
+            "corpus.mmindex.json",
+            "params.index.json",
+            "vocab.index.json",
+        ]
+
+        for fname in filenames:
+            error_msg = f"File {fname} not found in even though it should be saved by the .save() method"
+            path_exists = os.path.exists(os.path.join(self.temp_save_dir, fname))
+            self.assertTrue(path_exists, error_msg)
+
+    def test_save_and_reload(self):
+        self.retriever.save(self.temp_save_dir)
+        self.retriever_reloaded = SPLADE_GPU.load(
+            self.temp_save_dir, self.model, device="cpu"
+        )
+
+        ground_truth_ids = np.array([["zero", "three"]])
+        ground_truth_scores = np.array([[15.67, 8.17]], dtype="float32")
+        ground_truth_docs = np.array(
+            [
+                [
+                    "a cat is a feline and likes to purr",
+                    "a fish is a creature that lives in water and swims",
+                ]
+            ]
+        )
+
+        queries = np.array(["does the fish purr like a cat?"])
+
+        # Get top-k results as a tuple of (doc ids, documents, scores). All three are arrays of shape (n_queries, k).
+        results = self.retriever_reloaded.retrieve(queries, k=2)
+        doc_ids, result_docs, scores = (
+            results.doc_ids,
+            results.documents,
+            results.scores,
+        )
+
+        scores = np.round(scores, decimals=2)
+
+        self.assertTrue(
+            np.array_equal(doc_ids, ground_truth_ids),
+            f"Expected {ground_truth_ids}, got {doc_ids}",
+        )
+
+        self.assertTrue(
+            np.array_equal(scores, ground_truth_scores),
+            f"Expected {ground_truth_scores}, got {scores}",
+        )
+
+        self.assertTrue(
+            np.array_equal(result_docs, ground_truth_docs),
+            f"Expected {ground_truth_docs}, got {result_docs}",
+        )
+
+    def test_save_and_reload_mmap(self):
+        self.retriever.save(self.temp_save_dir)
+        self.retriever_reloaded = SPLADE_GPU.load(
+            self.temp_save_dir, self.model, mmap=True, device="cpu"
+        )
+
+        ground_truth_ids = np.array([["zero", "three"]])
+        ground_truth_scores = np.array([[15.67, 8.17]], dtype="float32")
+        ground_truth_docs = np.array(
+            [
+                [
+                    "a cat is a feline and likes to purr",
+                    "a fish is a creature that lives in water and swims",
+                ]
+            ]
+        )
+
+        queries = np.array(["does the fish purr like a cat?"])
+
+        # Get top-k results as a tuple of (doc ids, documents, scores). All three are arrays of shape (n_queries, k).
+        results = self.retriever_reloaded.retrieve(queries, k=2)
+        doc_ids, result_docs, scores = (
+            results.doc_ids,
+            results.documents,
+            results.scores,
+        )
+
+        scores = np.round(scores, decimals=2)
+
+        self.assertTrue(
+            np.array_equal(doc_ids, ground_truth_ids),
+            f"Expected {ground_truth_ids}, got {doc_ids}",
+        )
+
+        self.assertTrue(
+            np.array_equal(scores, ground_truth_scores),
+            f"Expected {ground_truth_scores}, got {scores}",
+        )
+
+        self.assertTrue(
+            np.array_equal(result_docs, ground_truth_docs),
+            f"Expected {ground_truth_docs}, got {result_docs}",
+        )


### PR DESCRIPTION
* Implemented a new class `splade_index.pytorch.SPLADE_GPU` that has the same methods as `splade_index.SPLADE` but enables 10x higher search throughput for large indices by making use of NVIDIA GPUs, PyTorch, and CUDA.

* Created new unit tests for `SPLADE_GPU` and updated the GitHub Action workflow .yml file to run the new tests

* Added a sample python code for using `SPLADE_GPU` to the README

* Updated the README to highlight the features of `splade-index`